### PR TITLE
Respect root_path from FastAPI

### DIFF
--- a/fastapi_offline/core.py
+++ b/fastapi_offline/core.py
@@ -1,7 +1,7 @@
 """Provide non-CDN-dependent Swagger & Redoc pages to FastAPI"""
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.openapi.docs import (
     get_redoc_html,
     get_swagger_ui_html,
@@ -39,13 +39,14 @@ def FastAPIOffline(*args: Any, **kwargs: Any) -> FastAPI:
 
     # Define the doc and redoc pages, pointing at the right files
     @app.get("/docs", include_in_schema=False)
-    async def custom_swagger_ui_html() -> "Response":
+    async def custom_swagger_ui_html(request: Request) -> "Response":
+        root = request.scope.get("root_path")
         return get_swagger_ui_html(
-            openapi_url=openapi_url,
+            openapi_url=f"{root}{openapi_url}",
             title=app.title + " - Swagger UI",
             oauth2_redirect_url=swagger_ui_oauth2_redirect_url,
-            swagger_js_url="/static-offline-docs/swagger-ui-bundle.js",
-            swagger_css_url="/static-offline-docs/swagger-ui.css",
+            swagger_js_url=f"{root}/static-offline-docs/swagger-ui-bundle.js",
+            swagger_css_url=f"{root}/static-offline-docs/swagger-ui.css",
         )
 
     @app.get(swagger_ui_oauth2_redirect_url, include_in_schema=False)
@@ -53,11 +54,12 @@ def FastAPIOffline(*args: Any, **kwargs: Any) -> FastAPI:
         return get_swagger_ui_oauth2_redirect_html()
 
     @app.get("/redoc", include_in_schema=False)
-    async def redoc_html() -> "Response":
+    async def redoc_html(request: Request) -> "Response":
+        root = request.scope.get("root_path")
         return get_redoc_html(
-            openapi_url=openapi_url,
+            openapi_url=f"{root}{openapi_url}",
             title=app.title + " - ReDoc",
-            redoc_js_url="/static-offline-docs/redoc.standalone.js",
+            redoc_js_url=f"{root}/static-offline-docs/redoc.standalone.js",
         )
 
     # Return the FastAPI object

--- a/tests/test_subapps.py
+++ b/tests/test_subapps.py
@@ -1,0 +1,90 @@
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from fastapi_offline import FastAPIOffline
+
+# Create an application with docs
+app = FastAPIOffline()
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+
+
+# Create a sub-application with no docs
+subapp_no_docs = FastAPI(openapi_url=None)
+
+
+@subapp_no_docs.get("/")
+async def sub_root():
+    return {"message": "Goodbye World"}
+
+
+app.mount("/sub_no_docs", subapp_no_docs)
+
+# Create a sub-application with docs
+subapp_yes_docs = FastAPIOffline()
+
+
+@subapp_yes_docs.get("/")
+async def sub2_root():
+    return {"message": "Congrats World"}
+
+
+app.mount("/sub_yes_docs", subapp_yes_docs)
+
+# Create a test client
+client = TestClient(app)
+
+# Check the main app still works
+def test_read_main():
+    """Hello World"""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello World"}
+
+
+# Test the sub apps work
+def test_sub_app():
+    """Goodbye World"""
+    response = client.get("/sub_no_docs/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Goodbye World"}
+
+
+def test_sub2_app():
+    """Congrats World"""
+    response = client.get("/sub_yes_docs/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Congrats World"}
+
+
+# Check the docs pages on the main app
+def test_read_docs():
+    for page in ["/docs", "/redoc"]:
+        response = client.get(page)
+        assert response.status_code == 200
+        assert "cdn.jsdelivr.net" not in response.text
+        assert "static-offline-docs" in response.text
+
+
+# Check the static pages on the main app
+def test_read_statics():
+    for page in ["swagger-ui-bundle.js", "swagger-ui.css", "redoc.standalone.js"]:
+        response = client.get("/static-offline-docs/" + page)
+        assert response.status_code == 200
+
+
+# Make sure that the first subapp doesn't have docs
+def test_subapp_no_docs():
+    response = client.get("/sub_no_docs/docs")
+    assert response.status_code == 404
+
+
+# Make sure the second does
+def test_subapp_yes_docs():
+    for page in ["sub_yes_docs/docs", "sub_yes_docs/redoc"]:
+        response = client.get(page)
+        assert response.status_code == 200
+        assert "cdn.jsdelivr.net" not in response.text
+        assert "sub_yes_docs/static-offline-docs" in response.text

--- a/tests/test_subapps2.py
+++ b/tests/test_subapps2.py
@@ -1,0 +1,64 @@
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from fastapi_offline import FastAPIOffline
+
+# Create an application with no docs
+app = FastAPI(openapi_url=None)
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+
+
+# Create a sub-app with docs
+
+sub_app = FastAPIOffline()
+
+
+@sub_app.get("/")
+async def subroot():
+    return {"message": "Goodbye World"}
+
+
+app.mount("/sub", sub_app)
+
+
+# Create a test client
+client = TestClient(app)
+
+
+# Test the actual endpoints
+def test_read_main():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello World"}
+
+
+def test_sub_main():
+    response = client.get("/sub/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Goodbye World"}
+
+
+# Check the docs pages on main are disabled
+def test_disabled_docs():
+    for page in ["/docs", "/redoc"]:
+        response = client.get(page)
+        assert response.status_code == 404
+
+
+# Check the docs pages on the subapp
+def test_read_docs():
+    for page in ["/sub/docs", "/sub/redoc"]:
+        response = client.get(page)
+        assert response.status_code == 200
+        assert "cdn.jsdelivr.net" not in response.text
+        assert "sub/static-offline-docs" in response.text
+
+
+# Check the static pages
+def test_read_statics():
+    for page in ["swagger-ui-bundle.js", "swagger-ui.css", "redoc.standalone.js"]:
+        response = client.get("/sub/static-offline-docs/" + page)
+        assert response.status_code == 200


### PR DESCRIPTION
As noted in #2, things broke rapidly once FastAPIOffline objects started getting connected as [sub-applications](https://fastapi.tiangolo.com/advanced/sub-applications/).

This patch should handle all those cases by respecting [root_path](https://fastapi.tiangolo.com/advanced/sub-applications/#technical-details-root_path).