### PR TITLE
Make documentation URLs configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,8 @@ async def root():
     return {"message": "Hello World"}
 ```
 
-Any options passed to `FastAPIOffline()` except `docs_url`, `redoc_url`, and `favicon_url` are passed through to `FastAPI()`.
+Any options passed to `FastAPIOffline()` except `docs_url`, `redoc_url`, and `favicon_url` are passed through to `FastAPI()`.  `docs_url` and `redoc_url` are handled by `fastapi-offline`, and use the same syntax as normal `fastapi` library.
 
-# Disabling Docs Page
-
-If you wish to [disable the docs page](https://fastapi.tiangolo.com/tutorial/metadata/#openapi-url), for 
-example in a sub-application, revert to using the default `FastAPI()` class.
-
-```py
-app = FastAPI(openapi_url=None)
-```
 # Using a custom shortcut icon
 
 By default, the FastAPI `favicon.png` is included and used as the shortcut icon on the docs pages.  If you want to use a different one, you can specify it with the `favicon_url` argument:

--- a/fastapi_offline/core.py
+++ b/fastapi_offline/core.py
@@ -71,6 +71,7 @@ def FastAPIOffline(
             return get_swagger_ui_oauth2_redirect_html()
 
     if redoc_url is not None:
+
         @app.get(redoc_url, include_in_schema=False)
         async def redoc_html(request: Request) -> "Response":
             root = request.scope.get("root_path")

--- a/tests/test_altpaths.py
+++ b/tests/test_altpaths.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from fastapi_offline import FastAPIOffline
+
+DOC = "/asdf"
+REDOC = "/qwerty"
+
+# Custom paths for both
+app1 = FastAPIOffline(docs_url=DOC, redoc_url=REDOC)
+client1 = TestClient(app1)
+
+# Disable redoc
+app2 = FastAPIOffline(docs_url=DOC, redoc_url=None)
+client2 = TestClient(app2)
+
+# Disable Swagger
+app3 = FastAPIOffline(docs_url=None, redoc_url=REDOC)
+client3 = TestClient(app3)
+
+
+def test_swagger():
+    """Make sure Swagger appears at the right place"""
+    assert client1.get("/docs").status_code == 404
+    assert client1.get(DOC).status_code == 200
+
+    assert client2.get("/docs").status_code == 404
+    assert client2.get(DOC).status_code == 200
+
+    assert client3.get("/docs").status_code == 404
+    assert client3.get(DOC).status_code == 404
+
+
+def test_custom_redocs():
+    """Make sure Redoc appears at the right place"""
+    assert client1.get("/redoc").status_code == 404
+    assert client1.get(REDOC).status_code == 200
+
+    assert client2.get("/redoc").status_code == 404
+    assert client2.get(REDOC).status_code == 404
+
+    assert client3.get("/redoc").status_code == 404
+    assert client3.get(REDOC).status_code == 200


### PR DESCRIPTION
Allow user to specify docs_url and redocs_url.  Both parameters
use the same syntax as in normal FastAPI.

Closes #17.