### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
       fail-fast: false
     
     steps:


### PR DESCRIPTION
Couple CI updates:
* CodeCov is deprecating their old uploader, and brownouts are starting in 2 weeks.  Switch to the new uploader.
* Python 3.10 is out.  Start running tests on it.  Plan to drop tests on Python 3.6 when it's deprecated on 23 December.