### PR TITLE
add py.typed to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     packages=["fastapi_offline"],
-    package_data={"fastapi_offline": ["static/*"]},
+    package_data={"fastapi_offline": ["static/*", "py.typed"]},
     python_requires=">=3.6",
     install_requires=["aiofiles", "fastapi"],
     tests_require=["pytest", "requests"],


### PR DESCRIPTION
This ensures that `py.typed` is included in installs from source distributions.

Example smoke test of this patch here: https://github.com/conda-forge/fastapi-offline-feedstock/pull/2