### PR TITLE
v1.4 prep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
       fail-fast: false
     
     steps:

--- a/fastapi_offline/consts.py
+++ b/fastapi_offline/consts.py
@@ -1,4 +1,4 @@
-SWAGGER_JS = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js"
-SWAGGER_CSS = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css"
+SWAGGER_JS = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui-bundle.js"
+SWAGGER_CSS = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui.css"
 REDOC_JS = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"
 FAVICON = "https://fastapi.tiangolo.com/img/favicon.png"

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ from setuptools import setup
 from setuptools.command.sdist import sdist
 
 
-__version__ = "1.3.2"
+__version__ = "1.4.0"
 
 
 BASE_PATH = Path(__file__).parent
 README = (BASE_PATH / "README.md").read_text()
-
+FASTAPI_VER = "fastapi>=0.75.2"
 
 class SDistWrapper(sdist):
     def run(self) -> None:
@@ -51,8 +51,8 @@ setup(
     packages=["fastapi_offline"],
     package_data={"fastapi_offline": ["static/*"]},
     python_requires=">=3.6",
-    install_requires=["fastapi"],
+    install_requires=[FASTAPI_VER],
     tests_require=["pytest", "requests"],
-    setup_requires=["fastapi"],
+    setup_requires=[FASTAPI_VER],
     cmdclass={"sdist": SDistWrapper},
 )

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup(
     packages=["fastapi_offline"],
     package_data={"fastapi_offline": ["static/*"]},
     python_requires=">=3.6",
-    install_requires=["aiofiles", "fastapi"],
+    install_requires=["fastapi"],
     tests_require=["pytest", "requests"],
-    setup_requires=["fastapi", "aiofiles"],
+    setup_requires=["fastapi"],
     cmdclass={"sdist": SDistWrapper},
 )

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     ],
     packages=["fastapi_offline"],
     package_data={"fastapi_offline": ["static/*"]},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[FASTAPI_VER],
     tests_require=["pytest", "requests"],
     setup_requires=[FASTAPI_VER],


### PR DESCRIPTION
In this release:
- remove unnecessary aiofiles dependency (@bollwyvl)
- move to python 3.7 (3.6 has passed end-of-life, and some libraries no longer work but don't explicitly say so)
- move to swagger v4