### PR TITLE
Enable configurable static paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ async def root():
     return {"message": "Hello World"}
 ```
 
-Any options passed to `FastAPIOffline()` except `docs_url`, `redoc_url`, and `favicon_url` are passed through to `FastAPI()`.  `docs_url` and `redoc_url` are handled by `fastapi-offline`, and use the same syntax as normal `fastapi` library.
+Any options passed to `FastAPIOffline()` except `docs_url`, `redoc_url`, `favicon_url`, and `static_url` are passed through to `FastAPI()`.  `docs_url` and `redoc_url` are handled by `fastapi-offline`, and use the same syntax as normal `fastapi` library.
+
+`static_url` can be used to set the path for the static js/css files, e.g. `static_url=/static-files` (default: `/static-offline-docs`).
 
 # Using a custom shortcut icon
 

--- a/fastapi_offline/core.py
+++ b/fastapi_offline/core.py
@@ -29,6 +29,9 @@ def FastAPIOffline(
     # Grab the user specified favicon url (if present)
     favicon_url = kwargs.pop("favicon_url", None)
 
+    # Set path to to static files or default to /static-offline-docs
+    static_url = kwargs.pop("static_url", "/static-offline-docs")
+
     # Create the FastAPI object
     app = FastAPI(*args, **kwargs)
 
@@ -41,7 +44,7 @@ def FastAPIOffline(
 
     # Set up static file mount
     app.mount(
-        "/static-offline-docs",
+        static_url,
         StaticFiles(directory=_STATIC_PATH.as_posix()),
         name="static-offline-docs",
     )
@@ -53,7 +56,7 @@ def FastAPIOffline(
             root = request.scope.get("root_path")
 
             if favicon_url is None:
-                favicon = f"{root}/static-offline-docs/favicon.png"
+                favicon = f"{root}{static_url}/favicon.png"
             else:
                 favicon = favicon_url
 
@@ -61,8 +64,8 @@ def FastAPIOffline(
                 openapi_url=f"{root}{openapi_url}",
                 title=app.title + " - Swagger UI",
                 oauth2_redirect_url=swagger_ui_oauth2_redirect_url,
-                swagger_js_url=f"{root}/static-offline-docs/swagger-ui-bundle.js",
-                swagger_css_url=f"{root}/static-offline-docs/swagger-ui.css",
+                swagger_js_url=f"{root}{static_url}/swagger-ui-bundle.js",
+                swagger_css_url=f"{root}{static_url}/swagger-ui.css",
                 swagger_favicon_url=favicon,
             )
 
@@ -77,14 +80,14 @@ def FastAPIOffline(
             root = request.scope.get("root_path")
 
             if favicon_url is None:
-                favicon = f"{root}/static-offline-docs/favicon.png"
+                favicon = f"{root}{static_url}/favicon.png"
             else:
                 favicon = favicon_url
 
             return get_redoc_html(
                 openapi_url=f"{root}{openapi_url}",
                 title=app.title + " - ReDoc",
-                redoc_js_url=f"{root}/static-offline-docs/redoc.standalone.js",
+                redoc_js_url=f"{root}{static_url}/redoc.standalone.js",
                 with_google_fonts=False,
                 redoc_favicon_url=favicon,
             )

--- a/tests/test_altpaths.py
+++ b/tests/test_altpaths.py
@@ -4,9 +4,10 @@ from fastapi_offline import FastAPIOffline
 
 DOC = "/asdf"
 REDOC = "/qwerty"
+STATIC = "/azerty"
 
-# Custom paths for both
-app1 = FastAPIOffline(docs_url=DOC, redoc_url=REDOC)
+# Custom paths for all
+app1 = FastAPIOffline(docs_url=DOC, redoc_url=REDOC, static_url=STATIC)
 client1 = TestClient(app1)
 
 # Disable redoc
@@ -40,3 +41,12 @@ def test_custom_redocs():
 
     assert client3.get("/redoc").status_code == 404
     assert client3.get(REDOC).status_code == 200
+
+def test_static():
+    """Make sure static files appears at the right place"""
+    for static_file in ["swagger-ui-bundle.js", "swagger-ui.css", "redoc.standalone.js"]:
+        assert client1.get(f"/static-offline-docs/{static_file}").status_code == 404
+        assert client1.get(f"{STATIC}/{static_file}").status_code == 200
+
+        assert client2.get(f"/static-offline-docs/{static_file}").status_code == 200
+        assert client2.get(f"{STATIC}/{static_file}").status_code == 404


### PR DESCRIPTION
For my projects I need to put my app in a sub-folder, e.g. `/myapp` and cannot serve files directly from `/` so I need to be able to configure the path to the static files.

I used the name `static_url` to keep in line with `redoc_url`, `favicon_url` and `docs_url`.

This is my first contribution to a python project and I am not a native English speaker but I hope it's okay and that this is functionality you want to add.