### PR TITLE
Fix static doc return annotations for FastAPI >= 0.89

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
       fail-fast: false
     
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install package, dependencies, and test tools
         run: |
           python setup.py sdist
-          python -m pip install dist/*.tar.gz
+          python -m pip install `ls -1 dist/*.tar.gz`[test]
           python -m pip install pytest pytest-cov flake8 black mypy
       - name: Check black compliance
         run : |

--- a/fastapi_offline/core.py
+++ b/fastapi_offline/core.py
@@ -1,6 +1,7 @@
 """Provide non-CDN-dependent Swagger & Redoc pages to FastAPI"""
 from pathlib import Path
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional
+
 from fastapi import FastAPI, Request
 from fastapi.openapi.docs import (
     get_redoc_html,
@@ -8,9 +9,7 @@ from fastapi.openapi.docs import (
     get_swagger_ui_oauth2_redirect_html,
 )
 from fastapi.staticfiles import StaticFiles
-
-if TYPE_CHECKING:
-    from fastapi import Response  # pragma: no cover
+from starlette.responses import HTMLResponse
 
 _STATIC_PATH = Path(__file__).parent / "static"
 
@@ -52,7 +51,7 @@ def FastAPIOffline(
     if docs_url is not None:
         # Define the doc and redoc pages, pointing at the right files
         @app.get(docs_url, include_in_schema=False)
-        async def custom_swagger_ui_html(request: Request) -> "Response":
+        async def custom_swagger_ui_html(request: Request) -> HTMLResponse:
             root = request.scope.get("root_path")
 
             if favicon_url is None:
@@ -70,13 +69,13 @@ def FastAPIOffline(
             )
 
         @app.get(swagger_ui_oauth2_redirect_url, include_in_schema=False)
-        async def swagger_ui_redirect() -> "Response":
+        async def swagger_ui_redirect() -> HTMLResponse:
             return get_swagger_ui_oauth2_redirect_html()
 
     if redoc_url is not None:
 
         @app.get(redoc_url, include_in_schema=False)
-        async def redoc_html(request: Request) -> "Response":
+        async def redoc_html(request: Request) -> HTMLResponse:
             root = request.scope.get("root_path")
 
             if favicon_url is None:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.command.sdist import sdist
 
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 
 
 BASE_PATH = Path(__file__).parent

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from urllib.request import urlretrieve
+
 from setuptools import setup
 from setuptools.command.sdist import sdist
-
 
 __version__ = "1.5.2"
 
@@ -10,11 +10,13 @@ __version__ = "1.5.2"
 BASE_PATH = Path(__file__).parent
 README = (BASE_PATH / "README.md").read_text()
 FASTAPI_VER = "fastapi>=0.75.2,!=0.89.0"
+TEST_DEPS = ["pytest", "requests", "starlette[full]"]
+
 
 class SDistWrapper(sdist):
     def run(self) -> None:
         "Download files into static/, then pass through to normal install"
-        from fastapi_offline.consts import SWAGGER_JS, SWAGGER_CSS, REDOC_JS, FAVICON
+        from fastapi_offline.consts import FAVICON, REDOC_JS, SWAGGER_CSS, SWAGGER_JS
 
         # Find ourself
 
@@ -52,7 +54,8 @@ setup(
     package_data={"fastapi_offline": ["static/*", "py.typed"]},
     python_requires=">=3.7",
     install_requires=[FASTAPI_VER],
-    tests_require=["pytest", "requests"],
+    tests_require=TEST_DEPS,
     setup_requires=[FASTAPI_VER],
+    extras_require={"test": TEST_DEPS},
     cmdclass={"sdist": SDistWrapper},
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ __version__ = "1.5.2"
 
 BASE_PATH = Path(__file__).parent
 README = (BASE_PATH / "README.md").read_text()
-FASTAPI_VER = "fastapi>=0.75.2"
+FASTAPI_VER = "fastapi>=0.75.2,!=0.89.0"
 
 class SDistWrapper(sdist):
     def run(self) -> None:


### PR DESCRIPTION
See #30 - FastAPI changed how it handles the generic `Response` type.  Replaced string references to `Response` (that were only there to keep mypy happy) with actual references to `starlette.responses.HTMLResponse` (which pydantic now actually uses for things).

Tested with most recent subversion of FastAPI from 0.75 to 0.89.

This is not compatible with FastAPI 0.89.0 - the fixes included in 0.89.1 are required.