### PR TITLE
Version bump.  Update URLs to match FastAPI.

### DIFF
--- a/fastapi_offline/__init__.py
+++ b/fastapi_offline/__init__.py
@@ -1,4 +1,5 @@
 """Provide non-CDN-dependent Swagger & Redoc pages to FastAPI"""
+
 from .core import FastAPIOffline
 
 __all__ = [

--- a/fastapi_offline/consts.py
+++ b/fastapi_offline/consts.py
@@ -1,4 +1,4 @@
-SWAGGER_JS = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.9.0/swagger-ui-bundle.js"
-SWAGGER_CSS = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.9.0/swagger-ui.css"
+SWAGGER_JS = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"
+SWAGGER_CSS = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css"
 REDOC_JS = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"
 FAVICON = "https://fastapi.tiangolo.com/img/favicon.png"

--- a/fastapi_offline/core.py
+++ b/fastapi_offline/core.py
@@ -1,4 +1,5 @@
 """Provide non-CDN-dependent Swagger & Redoc pages to FastAPI"""
+
 from pathlib import Path
 from typing import Any, Optional
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from urllib.request import build_opener, install_opener, urlretrieve
 from setuptools import setup
 from setuptools.command.sdist import sdist
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 
 BASE_PATH = Path(__file__).parent


### PR DESCRIPTION
* Bump version.
* Update URLs to match FastAPI (tiangolo/fastapi#11459)
* Vendor newest Swagger + Redoc JS on release.