### PR TITLE
Migrate to PEP517 build tooling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     
     steps:
@@ -20,10 +20,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
-        run: pip install flit setuptools pytest requests starlette[full] fastapi
+        run: pip install flit setuptools pytest requests starlette[full] fastapi build
       - name: Install package, dependencies, and test tools
         run: |
-          python setup.py sdist
+          python -m build . -sw
           python -m pip install `ls -1 dist/*.tar.gz`[test]
           python -m pip install pytest pytest-cov flake8 black mypy
       - name: Check black compliance

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from urllib.request import build_opener, install_opener, urlretrieve
 from setuptools import setup
 from setuptools.command.sdist import sdist
 
-__version__ = "1.7.4"
+__version__ = "1.7.5"
 
 
 BASE_PATH = Path(__file__).parent
@@ -53,7 +53,6 @@ setup(
     url="https://github.com/turettn/fastapi_offline",
     license="MIT",
     classifiers=[
-        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
     ],


### PR DESCRIPTION
* Drop testing for EOL Python 3.9
* Add testing for Python 3.14
* Use PEP517 build tooling instead of legacy setup.py action
* Remove obsolete license classifier in favor of license tag

Fixes #50 